### PR TITLE
fix: handle truncated gist content

### DIFF
--- a/src/services/gistService.ts
+++ b/src/services/gistService.ts
@@ -83,8 +83,19 @@ export async function getGist(gistId: string): Promise<Workspace> {
         throw new Error(`Gist does not contain the expected file: ${GIST_FILENAME}`);
     }
 
+    let content: string;
+    if (file.truncated) {
+        const res = await fetch(file.raw_url);
+        if (!res.ok) {
+            throw new Error(`Failed to retrieve truncated content from ${file.raw_url}`);
+        }
+        content = await res.text();
+    } else {
+        content = file.content;
+    }
+
     try {
-        const workspace: Workspace = JSON.parse(file.content);
+        const workspace: Workspace = JSON.parse(content);
         return workspace;
     } catch (e) {
         throw new Error('Failed to parse workspace data from Gist.');


### PR DESCRIPTION
The `getGist` function was failing to parse workspace data from gists when the content was truncated by the GitHub API. This change adds a check for the `truncated` flag in the file object and fetches the full content from the `raw_url` if it is set to true. This ensures that the complete JSON content is always parsed, preventing the 'Failed to parse workspace data from Gist' error for large workspace files.