### PR TITLE
feat: Add retry logic to LoliCode generation and fix build errors

### DIFF
--- a/src/app/api/gist/create/route.ts
+++ b/src/app/api/gist/create/route.ts
@@ -4,7 +4,6 @@ import type { Workspace } from '@/store/slices/workspaceSlice';
 import type { DetailedAnalysis } from '@/lib/analyzer/types';
 
 const GITHUB_API_URL = 'https://api.github.com';
-export const GIST_FILENAME = process.env.NEXT_PUBLIC_GIST_FILE_NAME || 'GeminiVaultAgentMemory.json';
 
 // StorableWorkspace to not include harEntries, which can be very large.
 interface StorableWorkspace {
@@ -13,6 +12,7 @@ interface StorableWorkspace {
 }
 
 async function createGistOnServer(workspace: StorableWorkspace): Promise<string> {
+    const GIST_FILENAME = process.env.NEXT_PUBLIC_GIST_FILE_NAME || 'GeminiVaultAgentMemory.json';
     const token = process.env.GIST_TOKEN;
     if (!token) {
         throw new Error('GIST_TOKEN is not configured on the server.');

--- a/src/app/api/githubToken/route.ts
+++ b/src/app/api/githubToken/route.ts
@@ -6,8 +6,6 @@ import type { Workspace } from '@/store/slices/workspaceSlice';
 
 const envFilePath = path.resolve(process.cwd(), '.env');
 const GITHUB_API_URL = 'https://api.github.com';
-export const GIST_FILENAME = process.env.NEXT_PUBLIC_GIST_FILE_NAME || 'GeminiVaultAgentMemory.json';
-
 
 async function getGistToken() {
   try {
@@ -33,6 +31,7 @@ export async function GET() {
 }
 
 async function createGistOnServer(workspace: Workspace): Promise<string> {
+    const GIST_FILENAME = process.env.NEXT_PUBLIC_GIST_FILE_NAME || 'GeminiVaultAgentMemory.json';
     const token = process.env.GIST_TOKEN;
     if (!token) {
         throw new Error('GIST_TOKEN is not configured on the server.');

--- a/src/hooks/useDashboardLogic.ts
+++ b/src/hooks/useDashboardLogic.ts
@@ -111,10 +111,10 @@ export function useDashboardLogic() {
     dispatch(openDetailModal(originalIndex));
   }, [dispatch, harEntries]);
 
-  const handleGenerateCode = useCallback((config: LoliCodeConfig) => {
+  const handleGenerateCode = useCallback(async (config: LoliCodeConfig) => {
     try {
       if (!analysis) throw new Error('No analysis available');
-      const code = generateLoliCode(config, filteredEntries, analysis);
+      const code = await generateLoliCode(config, filteredEntries, analysis, 3);
       setGeneratedCode(code);
       router.push('/dashboard/generator');
       toast({ title: "LoliCode Generated", description: `Successfully generated script with ${config.selectedIndices.length} requests.` });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,29 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Retries a function a specified number of times with a delay between retries.
+ * @param fn The async function to retry.
+ * @param retries The number of retries.
+ * @param delay The delay between retries in milliseconds.
+ * @returns A promise that resolves with the result of the function.
+ */
+export async function retry<T>(
+  fn: () => Promise<T>,
+  retries = 3,
+  delay = 1000
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let i = 0; i < retries; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error as Error;
+      if (i < retries - 1) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
This commit introduces a retry mechanism to the LoliCode generation process, making it more resilient to intermittent failures.

Key changes:
- Added a generic `retry` utility function.
- Refactored the `LoliCodeGenerator` to be asynchronous and use the `retry` utility.
- Updated the UI logic to call the new asynchronous generation function with a default of 3 retries.
- Fixed build errors related to invalid exports in Next.js route files.